### PR TITLE
Feature: add docker-compose for Go microservices and unified Dockerfile

### DIFF
--- a/backend/services/auth-service/main.go
+++ b/backend/services/auth-service/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func main() {
+	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("auth-service: OK"))
+	})
+	fmt.Println("auth-service running on :8001")
+	http.ListenAndServe(":8001", nil)
+}

--- a/backend/services/rec-service/main.go
+++ b/backend/services/rec-service/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func main() {
+	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("rec-service: OK"))
+	})
+	fmt.Println("rec-service running on :8003")
+	http.ListenAndServe(":8003", nil)
+}

--- a/backend/services/shower-service/main.go
+++ b/backend/services/shower-service/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func main() {
+	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("shower-service: OK"))
+	})
+	fmt.Println("shower-service running on :8002")
+	http.ListenAndServe(":8002", nil)
+}

--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -1,0 +1,29 @@
+FROM golang:1.24-alpine AS builder
+WORKDIR /app
+
+COPY backend/go.mod backend/go.sum ./
+RUN go mod download
+
+ARG SERVICE_DIR
+COPY ${SERVICE_DIR} ${SERVICE_DIR}
+
+ARG BINARY_NAME
+WORKDIR /app/${SERVICE_DIR}
+RUN CGO_ENABLED=0 GOOS=linux go build -o /${BINARY_NAME}
+
+FROM alpine:latest
+WORKDIR /app
+
+ARG BINARY_NAME
+ARG PORT
+
+COPY --from=builder /${BINARY_NAME} /app/
+COPY devops/entrypoint.sh /app/
+
+RUN chmod +x /app/entrypoint.sh && \
+    chmod +x /app/${BINARY_NAME}
+
+ENV PORT=${PORT}
+EXPOSE ${PORT}
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/devops/docker-compose.yml
+++ b/devops/docker-compose.yml
@@ -1,0 +1,75 @@
+services:
+  db:
+    image: postgres:13
+    restart: always
+    env_file:
+      - .env
+    environment:
+      POSTGRES_USER: tatar_shower
+      POSTGRES_PASSWORD: chinchanchonchi
+      POSTGRES_DB: shower_db
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  auth-service:
+    build:
+      context: ..
+      dockerfile: devops/Dockerfile
+      args:
+        SERVICE_DIR: backend/services/auth-service
+        BINARY_NAME: auth-service
+        PORT: "8001"
+    depends_on:
+      - db
+    env_file:
+      - .env
+    environment:
+      BINARY_NAME: auth-service
+      DATABASE_URL: postgres://tatar_shower:chinchanchonchi@db:5432/shower_db
+      JWT_SECRET: ${JWT_SECRET}
+      PORT: 8001
+    ports:
+      - "8001:8001"
+
+  shower-service:
+    build:
+      context: ..
+      dockerfile: devops/Dockerfile
+      args:
+        SERVICE_DIR: backend/services/shower-service
+        BINARY_NAME: shower-service
+        PORT: "8002"
+    depends_on:
+      - db
+    env_file:
+      - .env
+    environment:
+      BINARY_NAME: shower-service
+      DATABASE_URL: postgres://tatar_shower:chinchanchonchi@db:5432/shower_db
+      PORT: 8002
+    ports:
+      - "8002:8002"
+
+  rec-service:
+    build:
+      context: ..
+      dockerfile: devops/Dockerfile
+      args:
+        SERVICE_DIR: backend/services/rec-service
+        BINARY_NAME: rec-service
+        PORT: "8003"
+    depends_on:
+      - db
+    env_file:
+      - .env
+    environment:
+      BINARY_NAME: rec-service
+      DATABASE_URL: postgres://tatar_shower:chinchanchonchi@db:5432/shower_db
+      PORT: 8003
+    ports:
+      - "8003:8003"
+
+volumes:
+  db_data:

--- a/devops/entrypoint.sh
+++ b/devops/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec "/app/$BINARY_NAME"


### PR DESCRIPTION
# What was implemented:
Docker-based stack for our Go microservices: it introduces a Dockerfile with build args to compile any service, an entrypoint.sh to launch each binary by its name, and a docker-compose.yml that brings up PostgreSQL along with auth‐service, shower‐service, and rec‐service containers. Each backend service now includes a minimal main.go, and all required environment variables (database URL, JWT secret, ports) are loaded from devops/.env. Now we can build and run the backend with a single 
```"docker-compose up --build" ```